### PR TITLE
Add space below keyboard when necessary

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/b3fb4ebfc697cd42996bf7677eec151348ec8cf587a8e848313dda52d7322bbb-app.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>Woordle - Een dagelijks woordspelletje</title>
   <meta name="description" content="Zes beurten om het woord te gokken. Elke dag een nieuwe puzzel.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>

--- a/app/woordle6/index.html
+++ b/app/woordle6/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/b3fb4ebfc697cd42996bf7677eec151348ec8cf587a8e848313dda52d7322bbb-app.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>Woordle6 - Een dagelijks woordspelletje</title>
   <meta name="description" content="Zes beurten om het woord te gokken. Elke dag een nieuwe puzzel.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>

--- a/app/wordle/index.html
+++ b/app/wordle/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/6ab5dedbb163b04334d148037264f26c4efc095bb7303e546658c734c0d19009-app-en.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>WORDLE</title>
   <meta name="description" content="A Wordle clone.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>

--- a/app/wordle6/index.html
+++ b/app/wordle6/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/6ab5dedbb163b04334d148037264f26c4efc095bb7303e546658c734c0d19009-app-en.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>WORDLE6 - Six letter Wordle</title>
   <meta name="description" content="Try Wordle with six letters instead of five.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>

--- a/html/index.html
+++ b/html/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/app.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>Woordle - Een dagelijks woordspelletje</title>
   <meta name="description" content="Zes beurten om het woord te gokken. Elke dag een nieuwe puzzel.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>

--- a/html/woordle6/index.html
+++ b/html/woordle6/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/app.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>Woordle6 - Een dagelijks woordspelletje</title>
   <meta name="description" content="Zes beurten om het woord te gokken. Elke dag een nieuwe puzzel.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>

--- a/html/wordle/index.html
+++ b/html/wordle/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/app-en.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>WORDLE</title>
   <meta name="description" content="A Wordle clone.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>

--- a/html/wordle6/index.html
+++ b/html/wordle6/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <script type="text/javascript" src="/js/app-en.min.js"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <title>WORDLE6 - Six letter Wordle</title>
   <meta name="description" content="Try Wordle with six letters instead of five.">
@@ -33,6 +33,9 @@
       body {
         background: rgb(21, 23, 20); color: white;
       }
+    }
+    body > div {
+      padding-bottom: env(safe-area-inset-bottom) !important;
     }
   </style>
 </head>


### PR DESCRIPTION
To make the bottom-row of the keyboard safely usable on iPhones with a 'virtual' home-button, when used via "_Add to homescreen_".

| **Before:** | **After:** |
|------------|-----------|
|  ![screenshot current situation](https://user-images.githubusercontent.com/1009183/153776841-d10e1f69-3b15-4996-a3c5-cc2773ecc4dd.png) | ![screenshot after applying change](https://user-images.githubusercontent.com/1009183/153776821-003a50bd-1d91-4f54-9379-560feb1133f7.png) |

(On a iPhone 13 mini)

---

I didn't see any other way to add this specific CSS using Elm, so I've added it 'inline', also to the generated output.
But if there are other changes missing, let me know! 👍 