### PR TITLE
Remove some blocking steps from setup process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OPTIMIZE ?= --optimize
 SHELL = bash
 
 app/js/app-en.min.js: src/Main.elm
+	mkdir src-en
 	sed 's/{- English -}/English {-/' src/Main.elm > src-en/Main.elm
 	elm make $(OPTIMIZE) --output app-en.js src-en/Main.elm
 	if [[ -n "$(OPTIMIZE)" ]]; then

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Om de Elm compilatie juist te laten verlopen heb ik een Makefile gemaakt die bed
 De programma's die je nodig hebt zijn (en commando's voor macOS):
 
 - make (`brew install make`, gebruik commando `gmake`)
+- bash v4+ (`brew install bash`)
 - jq (`brew install jq`)
+- b3sum (`brew install b3sum`)
 - fswatch (`brew install fswatch`, alleen nodig voor `./preview.sh`)
 - python3 (`brew install python3`, alleen nodig voor `./preview.sh`)
 - elm ([installatie instructies op de Elm site][elm-install])

--- a/pre-push-hook
+++ b/pre-push-hook
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env bash
 
 # Disable push if latest app version wasn't exported to app folder
 


### PR DESCRIPTION
While I was setting up the app to run/build/export it locally, I ran into some missing dependencies/folders (on my machine).

So I've added them to the README.

- I'm not 100% sure this is the 'best'/fool-proof way to install Bash v4+, but it worked on my machine. ;)
- There could maybe also be a parameter for the `sed` program to create the destination-folder when it doesn't exist yet, but this way the script is also able to run from a 'clean slate'.
